### PR TITLE
Improve FCM connection health check

### DIFF
--- a/gorush/notification_fcm.go
+++ b/gorush/notification_fcm.go
@@ -3,10 +3,22 @@ package gorush
 import (
 	"errors"
 	"fmt"
-
 	"github.com/appleboy/go-fcm"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
+	"net/http"
+	"time"
 )
+
+func init() {
+	h2Transport, err := http2.ConfigureTransports(http.DefaultTransport.(*http.Transport))
+	if err != nil {
+		return
+	}
+	h2Transport.PingTimeout = 1 * time.Second
+	// avoid ErrCode=ENHANCE_YOUR_CALM (too many ping error)
+	h2Transport.ReadIdleTimeout = 5 * time.Second
+}
 
 // InitFCMClient use for initialize FCM Client.
 func InitFCMClient(key string) (*fcm.Client, error) {
@@ -15,7 +27,6 @@ func InitFCMClient(key string) (*fcm.Client, error) {
 	if key == "" {
 		return nil, errors.New("Missing Android API Key")
 	}
-
 	if key != PushConf.Android.APIKey {
 		return fcm.NewClient(key)
 	}


### PR DESCRIPTION
FCMサーバーはHttp2で通信しているので、APNsと同じ対策をFCMのクライアントにも使う

`GODEBUG=http2debug=2` を実行時に与えて次のテストコードを動かすと、Pingがとんでいることを確認できる

```golang
func Test(t *testing.T) {
	PushConf.Android.Enabled = true
	PushConf.Android.APIKey = "TestToken"
	// log for json
	PushConf.Log.Format = "json"

	androidToken := "TestToken"

	req := PushNotification{
		Tokens:   []string{androidToken},
		Platform: PlatFormAndroid,
		Message:  "Welcome",
	}
	for i := 0; i < 10; i++ {
		PushToAndroid(req)
		time.Sleep(10 * time.Second)
	}

}
```